### PR TITLE
Add CSS style to allow click of typeahead close button

### DIFF
--- a/dist/angular-typeahead.css
+++ b/dist/angular-typeahead.css
@@ -104,13 +104,11 @@
 }
 .typeahead-mobile-dropdown .typeahead-mobile-top {
   display: -webkit-box;
-  display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
 }
 .typeahead-mobile-input {
   -webkit-box-flex: 1;
-  -webkit-flex-grow: 1;
       -ms-flex-positive: 1;
           flex-grow: 1;
   font-size: 20px;
@@ -118,19 +116,18 @@
   outline: none;
 }
 .typeahead-mobile-close {
+  cursor: pointer;
   display: -webkit-box;
-  display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
   -webkit-box-orient: vertical;
   -webkit-box-direction: normal;
-  -webkit-flex-direction: column;
       -ms-flex-direction: column;
           flex-direction: column;
   -webkit-box-pack: center;
-  -webkit-justify-content: center;
       -ms-flex-pack: center;
           justify-content: center;
+  line-height: 48px;
   width: 48px;
   text-align: center;
   font-size: 48px;

--- a/dist/angular-typeahead.less
+++ b/dist/angular-typeahead.less
@@ -97,9 +97,11 @@
 }
 
 .typeahead-mobile-close {
+    cursor: pointer;
     display: flex;
     flex-direction: column;
     justify-content: center;
+    line-height: 48px;
     width: 48px;
     text-align: center;
     font-size: 48px;

--- a/src/typeahead.less
+++ b/src/typeahead.less
@@ -97,9 +97,11 @@
 }
 
 .typeahead-mobile-close {
+    cursor: pointer;
     display: flex;
     flex-direction: column;
     justify-content: center;
+    line-height: 48px;
     width: 48px;
     text-align: center;
     font-size: 48px;


### PR DESCRIPTION
Tested on iPhone 6s & 6s Plus w/ Safari 9 on BrowserStack. 
http://stackoverflow.com/questions/14795944/jquery-click-events-not-working-in-ios

Also set line-height style to vertically center the 'X' button - it was bottom-aligned when testing on BrowserStack.